### PR TITLE
Improve maze game with 10 goal-based levels

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,9 +25,10 @@
         top: 10px;
         left: 10px;
         background: rgba(255,255,255,0.8);
-        padding: 5px;
-        border-radius: 5px;
+        padding: 8px 12px;
+        border-radius: 8px;
         font-family: sans-serif;
+        font-size: 18px;
     }
     #editorOverlay {
         position: absolute;
@@ -51,6 +52,7 @@
   <button id="saveBtn">שמירה</button>
   <button id="loadBtn">טעינה</button>
   <button id="editBtn">עריכה</button>
+  <div style="margin-top:4px">היעד: להגיע לריבוע הירוק</div>
 </div>
 <canvas id="maze"></canvas>
 <div id="editorOverlay" style="display:none">מצב עריכה פעיל - לחץ על תאים כדי לשנות קיר. לחץ E כדי לצאת.</div>
@@ -66,8 +68,10 @@ let level = parseInt(localStorage.getItem('level')) || 1;
 let score = parseInt(localStorage.getItem('score')) || 0;
 let lives = parseInt(localStorage.getItem('lives')) || 3;
 let highScore = parseInt(localStorage.getItem('highScore')) || 0;
+const MAX_LEVEL = 10;
 let maze = [];
 let player = {x:1,y:1};
+let goal = {x:1,y:1};
 let enemies = [];
 let foods = [];
 let traps = [];
@@ -115,18 +119,27 @@ function generateMaze(width, height){
 }
 
 function startLevel(){
+  if(level>MAX_LEVEL){
+    alert('כל השלבים הושלמו!');
+    level=1; score=0; lives=3;
+  }
   const size=21+(level-1)*4;
   maze=generateMaze(size,size);
   canvas.width=maze[0].length*cellSize;
   canvas.height=maze.length*cellSize;
   player={x:1,y:1};
-  enemies=[{x:maze[0].length-2,y:maze.length-2,type:1}];
-  if(level>1) enemies.push({x:1,y:maze.length-2,type:2});
+  goal={x:maze[0].length-2,y:maze.length-2};
+  const enemySpeed=Math.max(1,3-Math.floor((level-1)/3));
+  enemies=[{x:goal.x,y:goal.y,type:1,speed:enemySpeed,cooldown:0}];
+  if(level>3) enemies.push({x:1,y:maze.length-2,type:2,speed:enemySpeed+1,cooldown:0});
   foods=[]; traps=[];
-  for(let y=0;y<maze.length;y++)
-    for(let x=0;x<maze[y].length;x++)
-      if(maze[y][x]==' ' && !(x==player.x&&y==player.y)) foods.push({x,y});
-  if(level>2) traps.push({x:Math.floor(maze[0].length/2),y:1,dx:0,dy:1,range:maze.length-2,step:0});
+  for(let i=0;i<level*3;i++){
+    let x,y;
+    do{ x=Math.floor(Math.random()*maze[0].length); y=Math.floor(Math.random()*maze.length); }
+    while(maze[y][x]!=' '|| (x==player.x&&y==player.y) || (x==goal.x&&y==goal.y));
+    foods.push({x,y});
+  }
+  if(level>5) traps.push({x:Math.floor(maze[0].length/2),y:1,dx:0,dy:1,range:maze.length-2,step:0});
   updateHUD();
   requestAnimationFrame(draw);
 }
@@ -176,7 +189,12 @@ function move(dx,dy){
     player={x:nx,y:ny};
     foods=foods.filter(f=>{
       if(f.x==nx&&f.y==ny){score+=10;playEatSound();return false;}return true;});
-    if(foods.length===0){playWinSound();level++;startLevel();return;}
+    if(player.x===goal.x && player.y===goal.y){
+      playWinSound();
+      level++;
+      startLevel();
+      return;
+    }
   }
   moveEnemies();
   updateTraps();
@@ -187,6 +205,7 @@ function move(dx,dy){
 function moveEnemies(){
   const dirs=[{x:1,y:0},{x:-1,y:0},{x:0,y:1},{x:0,y:-1}];
   enemies.forEach(e=>{
+    if(e.cooldown>0){e.cooldown--;return;}
     if(e.type===1){
       const step=findNextStep(e, player);
       if(step) { e.x=step.x; e.y=step.y; }
@@ -195,6 +214,7 @@ function moveEnemies(){
       dirs.forEach(d=>{const nx=e.x+d.x,ny=e.y+d.y;if(canMove(nx,ny)) opts.push({x:nx,y:ny});});
       if(opts.length) Object.assign(e,opts[Math.floor(Math.random()*opts.length)]);
     }
+    e.cooldown=e.speed;
     if(e.x==player.x&&e.y==player.y) hit();
   });
 }
@@ -238,7 +258,9 @@ function draw(){
   ctx.clearRect(0,0,canvas.width,canvas.height);
   for(let y=0;y<maze.length;y++)
     for(let x=0;x<maze[y].length;x++)
-      if(maze[y][x]=='#'){ctx.fillStyle='#444';ctx.fillRect(x*cellSize,y*cellSize,cellSize,cellSize);} 
+      if(maze[y][x]=='#'){ctx.fillStyle='#444';ctx.fillRect(x*cellSize,y*cellSize,cellSize,cellSize);}
+  ctx.fillStyle='green';
+  ctx.fillRect(goal.x*cellSize,goal.y*cellSize,cellSize,cellSize);
   ctx.fillStyle='gold';
   foods.forEach(f=>{ctx.beginPath();ctx.arc(f.x*cellSize+cellSize/2,f.y*cellSize+cellSize/2,cellSize/6,0,Math.PI*2);ctx.fill();});
   ctx.fillStyle='blue'; ctx.beginPath(); ctx.arc(player.x*cellSize+cellSize/2,player.y*cellSize+cellSize/2,cellSize/3,0,Math.PI*2); ctx.fill();


### PR DESCRIPTION
## Summary
- add a maximum of 10 levels and clear goal tile
- slow enemies using cooldown and vary their speed per level
- let level progress when player reaches the goal square
- place random food items for scoring only
- display goal tile and improved HUD instructions and style

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6853e6232b10832bbb51365527a226fa